### PR TITLE
sdlrenderer: C89 support

### DIFF
--- a/demo/sdl_sdlrenderer/Makefile
+++ b/demo/sdl_sdlrenderer/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c99 -pedantic -O0
+CFLAGS += -std=c89 -pedantic -O0
 CFLAGS += `sdl2-config --cflags`
 
 SRC = main.c

--- a/demo/sdl_sdlrenderer/main.c
+++ b/demo/sdl_sdlrenderer/main.c
@@ -71,6 +71,7 @@ main(int argc, char *argv[])
     SDL_Window *win;
     SDL_Renderer *renderer;
     int running = 1;
+    int flags = 0;
 
     /* GUI */
     struct nk_context *ctx;
@@ -89,7 +90,6 @@ main(int argc, char *argv[])
         exit(-1);
     }
 
-    int flags = 0;
     flags |= SDL_RENDERER_ACCELERATED;
     flags |= SDL_RENDERER_PRESENTVSYNC;
 


### PR DESCRIPTION
@1bsyl Would you mind testing this out? I'm not able to run it because I don't have the new SDL yet.

```
➜  sdl_sdlrenderer git:(sdl-renderer-c89) make
rm -f bin/demo 
cc main.c -std=c89 -pedantic -O0 `sdl2-config --cflags` -o bin/demo -lm -ldl `sdl2-config --libs`
/usr/bin/ld: /tmp/ccqcLIoC.o: in function `nk_sdl_render':
main.c:(.text+0x574d5): undefined reference to `SDL_RenderGeometryRaw'
collect2: error: ld returned 1 exit status
```